### PR TITLE
Add support for new, expanded lockfiles

### DIFF
--- a/lib/lockfile.ex
+++ b/lib/lockfile.ex
@@ -7,6 +7,13 @@ defmodule Lockfile do
 
   defp extract_deps({:ok, {_, _, deps}}), do: extract_deps(deps)
   defp extract_deps(deps) do
-    Enum.map(deps, fn({_, {_, _, [source, lib, version]}}) -> {source, lib, version} end)
+    Enum.map(deps, &extract_dep/1)
+  end
+
+  defp extract_dep({_, {_, _, [source, lib, version, _, _, _]}}) do
+    {source, lib, version}
+  end
+  defp extract_dep({_, {_, _, [source, lib, version]}}) do
+    {source, lib, version}
   end
 end

--- a/test/fixtures/newlockfile
+++ b/test/fixtures/newlockfile
@@ -1,0 +1,5 @@
+%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
+  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
+  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}

--- a/test/mixup_test.exs
+++ b/test/mixup_test.exs
@@ -32,4 +32,13 @@ defmodule MixupTest do
 
     assert json == "{\"cowboy\":{\"version\":\"1.0.0\",\"source\":\"hex\"}}"
   end
+
+  test "encoder can encode new lockfiles" do
+    {:ok, lockfile} = File.read("./test/fixtures/newlockfile")
+    result = Lockfile.parse(lockfile)
+
+    json = Encoder.lockfile_json(result)
+
+    assert json == "{\"cowboy\":{\"version\":\"1.0.0\",\"source\":\"hex\"}}"
+  end
 end

--- a/test/mixup_test.exs
+++ b/test/mixup_test.exs
@@ -39,6 +39,6 @@ defmodule MixupTest do
 
     json = Encoder.lockfile_json(result)
 
-    assert json == "{\"cowboy\":{\"version\":\"1.0.0\",\"source\":\"hex\"}}"
+    assert json == "{\"ranch\":{\"version\":\"1.2.1\",\"source\":\"hex\"},\"poison\":{\"version\":\"2.1.0\",\"source\":\"hex\"},\"plug\":{\"version\":\"1.1.6\",\"source\":\"hex\"},\"cowlib\":{\"version\":\"1.0.2\",\"source\":\"hex\"},\"cowboy\":{\"version\":\"1.0.4\",\"source\":\"hex\"}}"
   end
 end


### PR DESCRIPTION
Hex now includes more info in the lockfile, need to be able to support both old and new formats.
