### PR TITLE
Adds support for github urls in mixfiles.

### DIFF
--- a/lib/lockfile.ex
+++ b/lib/lockfile.ex
@@ -20,6 +20,10 @@ defmodule Lockfile do
     {source, lib, version}
   end
 
+  defp extract_dep({_, {_, _, [source, lib, version, _]}}) do
+    {source, lib, version}
+  end
+
   defp extract_dep({_, {_, _, [source, lib, version]}}) do
     {source, lib, version}
   end

--- a/test/fixtures/mixfile
+++ b/test/fixtures/mixfile
@@ -27,9 +27,14 @@ defmodule Mixup.Mixfile do
   #
   #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
   #
+  # Or github repositories:
+  #
+  #   {:mydep, github: "elixir-lang/mydep"}}
+  #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:poison, "~> 1.3.1"},
-      {:plug, "~> 0.11.0"}]
+    [{:oauth, github: "tim/erlang-oauth"},
+      {:poison, "~> 1.3.1"},
+      {:plug, "~> 0.11.0"},]
   end
 end

--- a/test/fixtures/newlockfile
+++ b/test/fixtures/newlockfile
@@ -1,5 +1,6 @@
 %{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
+  "oauth": {:git, "https://github.com/tim/erlang-oauth.git", "bd19896e31125f99ff45bb5850b1c0e74b996743", []},
   "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}

--- a/test/mixup_test.exs
+++ b/test/mixup_test.exs
@@ -12,7 +12,7 @@ defmodule MixupTest do
     {:ok, mixfile} = File.read("./test/fixtures/mixfile")
     result = Mixfile.parse(mixfile)
 
-    assert result == [poison: "~> 1.3.1", plug: "~> 0.11.0"]
+    assert result == [oauth: [github: "tim/erlang-oauth"], poison: "~> 1.3.1", plug: "~> 0.11.0"]
   end
 
   test "encoder can encode mixfiles" do
@@ -21,7 +21,7 @@ defmodule MixupTest do
 
     json = Encoder.mixfile_json(result)
 
-    assert json == "{\"poison\":\"~> 1.3.1\",\"plug\":\"~> 0.11.0\"}"
+    assert json == "{\"poison\":\"~> 1.3.1\",\"plug\":\"~> 0.11.0\",\"oauth\":\"HEAD\"}"
   end
 
   test "encoder can encode lockfiles" do
@@ -40,7 +40,7 @@ defmodule MixupTest do
     json = Encoder.lockfile_json(result)
 
     assert json ==
-             "{\"ranch\":{\"version\":\"1.2.1\",\"source\":\"hex\"},\"poison\":{\"version\":\"2.1.0\",\"source\":\"hex\"},\"plug\":{\"version\":\"1.1.6\",\"source\":\"hex\"},\"cowlib\":{\"version\":\"1.0.2\",\"source\":\"hex\"},\"cowboy\":{\"version\":\"1.0.4\",\"source\":\"hex\"}}"
+             "{\"https://github.com/tim/erlang-oauth.git\":{\"version\":\"bd19896e31125f99ff45bb5850b1c0e74b996743\",\"source\":\"git\"},\"ranch\":{\"version\":\"1.2.1\",\"source\":\"hex\"},\"poison\":{\"version\":\"2.1.0\",\"source\":\"hex\"},\"plug\":{\"version\":\"1.1.6\",\"source\":\"hex\"},\"cowlib\":{\"version\":\"1.0.2\",\"source\":\"hex\"},\"cowboy\":{\"version\":\"1.0.4\",\"source\":\"hex\"}}"
   end
 
   test "lockfile can parse newest lockfiles" do


### PR DESCRIPTION
Currently the lockfile endpoint returns a 422 for certain lockfiles. After some investigation it looks like it's failing when we have Mixfile lines with fewer arguments. 

